### PR TITLE
Add initial ci pipelines

### DIFF
--- a/tekton/resolution-ci-run.yaml
+++ b/tekton/resolution-ci-run.yaml
@@ -1,0 +1,32 @@
+# Copyright 2022 The Tekton Authors
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: resolution-ci-run-
+spec:
+  pipelineRef:
+    name: resolution-ci
+  params:
+    - name: revision
+      value: main
+  workspaces:
+    - name: ws
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/tekton/resolution-ci.yaml
+++ b/tekton/resolution-ci.yaml
@@ -1,0 +1,67 @@
+# Copyright 2022 The Tekton Authors
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: Pipeline
+apiVersion: tekton.dev/v1beta1
+metadata:
+  name: resolution-ci
+spec:
+
+  params:
+  - name: package
+    description: package to build/test
+    default: ./...
+  - name: repo
+    description: repo url to clone
+    default: https://github.com/tektoncd/resolution
+  - name: revision
+    description: the git revision to checkout
+    default: main
+
+  workspaces:
+  - name: ws
+
+  tasks:
+  - name: checkout
+    taskRefs:
+      name: git-clone
+    params:
+    - name: url
+      value: $(params.repo)
+    - name: revision
+      value: $(params.revision)
+    workspaces:
+    - name: output
+      workspace: ws
+
+  - name: unit-tests
+    runAfter: [checkout]
+    taskRef:
+      name: golang-test
+    params:
+    - name: package
+      value: $(params.package)
+    workspaces:
+    - name: source
+      workspace: ws
+
+  - name: build
+    runAfter: [checkout]
+    taskRef:
+      name: golang-build
+    params:
+    - name: package
+      value: $(params.package)
+    workspaces:
+    - name: source
+      workspace: ws


### PR DESCRIPTION
Prior to this commit we didn't have any ci pipelines defined in the
repo.

This just adds an initial basic pipeline that clones, builds and unit
tests the tektoncd/remote repo. These aren't in active use in our ci
right now but is a foothold on the way to something better defined.