### PR TITLE
Tidy up doc licenses and add howto to docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ $ ko apply -f ./config
 
 2. Install [the Git resolver](./gitresolver/README.md).
 
+---
+
 Except as otherwise noted, the content of this page is licensed under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
 and code samples are licensed under the

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,14 @@
 For new users getting started with Tekton Resolution check out the
 [getting-started.md](./getting-started.md) tutorial.
 
+## Developer Howto: Writing a Resolver From Scratch
+
+For a developer getting started with writing a new Resolver, see
+[how-to-write-a-resolver.md](./how-to-write-a-resolver.md) and the
+accompanying [resolver-template](./resolver-template).
+
+---
+
 Except as otherwise noted, the content of this page is licensed under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
 and code samples are licensed under the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -189,6 +189,8 @@ kubectl logs run-basic-pipeline-from-git-task-1-pod
 # This should print "hello liza"
 ```
 
+---
+
 Except as otherwise noted, the content of this page is licensed under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
 and code samples are licensed under the

--- a/docs/how-to-write-a-resolver.md
+++ b/docs/how-to-write-a-resolver.md
@@ -426,6 +426,8 @@ Finally, another direction you could take this would be to try writing a
 you get a `PipelineRun` to execute successfully that uses the hard-coded
 `Pipeline` your Resolver returns?
 
+---
+
 Except as otherwise noted, the content of this page is licensed under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
 and code samples are licensed under the

--- a/docs/resolver-template/README.md
+++ b/docs/resolver-template/README.md
@@ -57,6 +57,8 @@ field.
 
 This Resolver has no parameters.
 
+---
+
 Except as otherwise noted, the content of this page is licensed under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
 and code samples are licensed under the

--- a/gitresolver/README.md
+++ b/gitresolver/README.md
@@ -62,6 +62,8 @@ field.
 | `branch`   | The branch name to checkout a file from. Either this or commit but not both. | `main`                                       |
 | `path`     | Where to find the file in the repo.                                          | `/task/golang-build/0.3/golang-build.yaml`   |
 
+---
+
 Except as otherwise noted, the content of this page is licensed under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
 and code samples are licensed under the


### PR DESCRIPTION
Prior to this commit we didn't link to the new howto guide for
developers from the `docs/` README.md file.

This commit adds a link to the howto from `docs/README.md` and adds a
line separator to all docs so that their license is clearly demarcated
from their core content.