### PR TITLE
Add list of resolvers to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,16 @@ the `ResolutionRequest` controller from the root of this repo:
 $ ko apply -f ./config
 ```
 
-2. Install [the Git resolver](./gitresolver/README.md).
+2. [Install a resolver](#resolvers) or [get started writing your
+   own](./docs/how-to-write-a-resolver.md).
+
+## Resolvers
+
+| Name                                                        | Description                                                                     | Status    |
+|-------------------------------------------------------------|---------------------------------------------------------------------------------|-----------|
+| [`Bundle`](./bundleresolver)                                | Returns entries from oci bundles                                                | Pre-Alpha |
+| [`Git`](./gitresolver)                                      | Returns files from git repos                                                    | Pre-Alpha |
+| [`ClusterScoped`](https://github.com/sbwsg/clusterresolver) | Share a single set of tasks and pipelines across all namespaces in your cluster | Pre-Alpha |
 
 ---
 

--- a/bundleresolver/README.md
+++ b/bundleresolver/README.md
@@ -1,5 +1,15 @@
 # Bundles Resolver
 
+## Parameters
+
+| Param Name       | Description                                                                   | Example Value                                              |
+|------------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
+| `namespace`      | The namespace of the service account to use                                   | `default`                                                  |
+| `serviceAccount` | The name of the service account to use when constructing registry credentials | `default`                                                  |
+| `bundle`         | The bundle url pointing at the image to fetch                                 | `gcr.io/tekton-releases/catalog/upstream/golang-build:0.1` |
+| `name`           | The name of the resource to pull out of the bundle                            | `golang-build`                                             |
+| `kind`           | The resource kind to pull out of the bundle                                   | `task`                                                     |
+
 ## Getting Started
 
 ### Requirements
@@ -47,16 +57,6 @@ $ kubectl get resolutionrequest -w fetch-catalog-task
 You should shortly see the `ResolutionRequest` succeed and the content of
 the `golang-build.yaml` file base64-encoded in the object's `status.data`
 field.
-
-## Parameters
-
-| Param Name       | Description                                                                   | Example Value                                              |
-|------------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
-| `namespace`      | The namespace of the service account to use                                   | `default`                                                  |
-| `serviceAccount` | The name of the service account to use when constructing registry credentials | `default`                                                  |
-| `bundle`         | The bundle url pointing at the image to fetch                                 | `gcr.io/tekton-releases/catalog/upstream/golang-build:0.1` |
-| `name`           | The name of the resource to pull out of the bundle                            | `golang-build`                                             |
-| `kind`           | The resource kind to pull out of the bundle                                   | `task`                                                     |
 
 ---
 

--- a/docs/resolver-template/README.md
+++ b/docs/resolver-template/README.md
@@ -3,6 +3,12 @@
 This directory contains a working Resolver based on the instructions
 from the [developer howto in the docs](../how-to-write-a-resolver.md).
 
+## Parameters
+
+| Name   | Desccription                 | Example Value               |
+|--------|------------------------------|-----------------------------|
+| `url`  | The repository url.          | `https://example.com/repo/` |
+
 ## Using the template to start a new Resolver
 
 You can use this as a template to quickly get a new Resolver up and
@@ -68,10 +74,6 @@ field.
 ## What's Supported?
 
 - Just one hard-coded `Pipeline` for demonstration purposes.
-
-## Parameters
-
-This Resolver has no parameters.
 
 ---
 

--- a/gitresolver/README.md
+++ b/gitresolver/README.md
@@ -1,5 +1,14 @@
 # Simple Git Resolver
 
+## Parameters
+
+| Param Name | Description                                                                  | Example Value                                |
+|------------|------------------------------------------------------------------------------|----------------------------------------------|
+| `url`      | URL of the repo to fetch.                                                    | `https://github.com/tektoncd/catalog.git`    |
+| `commit`   | git commit SHA to checkout a file from.                                      | `aeb957601cf41c012be462827053a21a420befca`   |
+| `branch`   | The branch name to checkout a file from. Either this or commit but not both. | `main`                                       |
+| `path`     | Where to find the file in the repo.                                          | `/task/golang-build/0.3/golang-build.yaml`   |
+
 ## Getting Started
 
 ### Requirements
@@ -52,15 +61,6 @@ field.
   object will be automatically failed after 60 seconds. Both of these
   timeouts need to be exposed for operator control via ConfigMap or
   similar but at the moment are just hard-coded.
-
-## Parameters
-
-| Param Name | Description                                                                  | Example Value                                |
-|------------|------------------------------------------------------------------------------|----------------------------------------------|
-| `url`      | URL of the repo to fetch.                                                    | `https://github.com/tektoncd/catalog.git`    |
-| `commit`   | git commit SHA to checkout a file from.                                      | `aeb957601cf41c012be462827053a21a420befca`   |
-| `branch`   | The branch name to checkout a file from. Either this or commit but not both. | `main`                                       |
-| `path`     | Where to find the file in the repo.                                          | `/task/golang-build/0.3/golang-build.yaml`   |
 
 ---
 


### PR DESCRIPTION
Prior to this commit the list of resolvers that a user could install was
not easy to find.

This commit updates the root README.md with a list of the resolvers that
can be installed right now. It also points users who want to develop a
resolver to the how-to-write-a-resolver.md doc.

/kind documentation