### PR TITLE
Remove reference to in-progres pipelines PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Tekton Resolution is aiming for the following near-term goals:
 
 ### Requirements
 
-- A cluster running this [in-progress pull request of Tekton Pipelines](https://github.com/tektoncd/pipeline/pull/4596)
+- A cluster running the [Tekton Pipelines from its main branch](https://github.com/tektoncd/pipeline)
   with the `alpha` feature gate enabled.
 - `ko` installed.
 

--- a/bundleresolver/README.md
+++ b/bundleresolver/README.md
@@ -13,7 +13,7 @@
 
 ### Requirements
 
-- A cluster running this [in-progress pull request of Tekton Pipelines](https://github.com/tektoncd/pipeline/pull/4596)
+- A cluster running [Tekton Pipelines from its main branch](https://github.com/tektoncd/pipeline)
   with the `alpha` feature gate enabled.
 - `ko` installed.
 - The `tekton-remote-resolution` namespace and `ResolutionRequest`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,15 +34,9 @@ git clone https://github.com/tektoncd/pipeline
 
 # cd into the fetched repo
 cd pipeline
-
-# fetch the dev copy of pipelines we're using for this guide
-git fetch origin pull/4596/head:pipeline_remote_resolution_dev
-
-# checkout the dev branch
-git checkout pipeline_remote_resolution_dev
 ```
 
-And then install pipelines from this dev branch:
+And then install pipelines from its main branch:
 
 ```sh
 ko apply -f ./config/100-namespace

--- a/gitresolver/README.md
+++ b/gitresolver/README.md
@@ -13,7 +13,7 @@
 
 ### Requirements
 
-- A cluster running this [in-progress pull request of Tekton Pipelines](https://github.com/tektoncd/pipeline/pull/4596)
+- A cluster running [Tekton Pipelines from its main branch](https://github.com/tektoncd/pipeline)
   with the `alpha` feature gate enabled.
 - `ko` installed.
 - The `tekton-remote-resolution` namespace and `ResolutionRequest`

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,8 +23,6 @@ local failed=0
 header "Deploying Tekton Pipelines"
 git clone https://github.com/tektoncd/pipeline
 cd pipeline
-git fetch origin pull/4596/head:pipeline_remote_resolution_dev
-git checkout pipeline_remote_resolution_dev
 ko apply -f ./config/100-namespace
 ko apply -f ./config
 cd -
@@ -41,6 +39,10 @@ ko apply -f ./bundleresolver/config
 
 header "Deploying Resolver Template"
 ko apply -f ./docs/resolver-template/config
+
+# update the feature-flags configmap in the tekton-pipelines namespace
+# so that remote resolution is enabled
+kubectl patch -n tekton-pipelines configmap feature-flags -p '{"data":{"enable-api-fields":"alpha"}}'
 
 wait_until_pods_running "tekton-remote-resolution" || fail_test "Tekton Resolution did not come up"
 


### PR DESCRIPTION
Prior to this commit installation instructions sent users to an
in-progress pull request in the pipelines repo. Now that initial support
for resolution is merged for pipelineRefs that PR can be replaced with
installing pipelines directly from its main branch.

This commit updates installation instructions and our e2e test script to
pull pipelines in from its main branch.