### PR TITLE
E2E test Tekton Pipelines + Bundle Resolver

### DIFF
--- a/bundleresolver/cmd/bundleresolver/main.go
+++ b/bundleresolver/cmd/bundleresolver/main.go
@@ -54,7 +54,7 @@ func (r *resolver) GetName(context.Context) string {
 // GetSelector returns a map of labels to match requests to this resolver.
 func (r *resolver) GetSelector(context.Context) map[string]string {
 	return map[string]string{
-		common.LabelKeyResolverType: "bundle",
+		common.LabelKeyResolverType: "bundles",
 	}
 }
 

--- a/bundleresolver/pkg/bundle/params.go
+++ b/bundleresolver/pkg/bundle/params.go
@@ -34,6 +34,8 @@ const ParamName = "name"
 // image is.
 const ParamKind = "kind"
 
+const defaultServiceAccountName = "default"
+
 // OptionsFromParams parses the params from a resolution request and
 // converts them into options to pass as part of a bundle request.
 func OptionsFromParams(params map[string]string) (RequestOptions, error) {
@@ -41,7 +43,7 @@ func OptionsFromParams(params map[string]string) (RequestOptions, error) {
 
 	sa, ok := params[ParamServiceAccount]
 	if !ok {
-		return opts, fmt.Errorf("parameter %q required", ParamServiceAccount)
+		sa = defaultServiceAccountName
 	}
 
 	bundle, ok := params[ParamBundle]

--- a/test/bundles_test/bundles_test.go
+++ b/test/bundles_test/bundles_test.go
@@ -46,14 +46,15 @@ const waitInterval = time.Second
 // successful resolution of the test's bundle request.
 const waitTimeout = 20 * time.Second
 
-func TestBundleSmoke(t *testing.T) {
+// TestBundlesSmoke creates a resolution request for a bundle and checks
+// that it succeeds.
+func TestBundlesSmoke(t *testing.T) {
 	ctx := context.Background()
 	configPath := knativetest.Flags.Kubeconfig
 	clusterName := knativetest.Flags.Cluster
 
 	requestYAML, err := os.ReadFile("./resolution-request.yaml")
 	if err != nil {
-		t.Log(os.Getwd())
 		t.Fatalf("unable to read resolution request yaml fixture: %v", err)
 	}
 

--- a/test/bundles_test/resolution-request.yaml
+++ b/test/bundles_test/resolution-request.yaml
@@ -3,7 +3,7 @@ apiVersion: resolution.tekton.dev/v1alpha1
 metadata:
   name: bundle-resolution-request
   labels:
-    resolution.tekton.dev/type: bundle
+    resolution.tekton.dev/type: bundles
 spec:
   params:
     serviceAccount: default

--- a/test/helpers/read_file_to_object.go
+++ b/test/helpers/read_file_to_object.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// ReadFileToObject reads a file given a path relative to PWD and attempts
+// to parse it into the given k8s runtime object.
+func ReadFileToObject(filename string, obj runtime.Object) error {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("error reading %q: %w", filename, err)
+	}
+	_, _, err = scheme.Codecs.UniversalDeserializer().Decode(content, nil, obj)
+	if err != nil {
+		return fmt.Errorf("error parsing %q: %w", filename, err)
+	}
+	return nil
+}

--- a/test/pipeline_bundles_test/pipeline.yaml
+++ b/test/pipeline_bundles_test/pipeline.yaml
@@ -1,0 +1,35 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: hello-pipeline
+spec:
+  params:
+  - name: username
+    default: user
+  tasks:
+  - name: say-hello
+    params:
+    - name: username
+      value: $(params.username)
+    taskSpec:
+      params:
+      - name: username
+      steps:
+      - name: greet-user
+        image: alpine:3.15.4
+        script: |
+          echo "hello, $(params.username)"

--- a/test/pipeline_bundles_test/pipeline_bundles_test.go
+++ b/test/pipeline_bundles_test/pipeline_bundles_test.go
@@ -1,0 +1,280 @@
+//go:build e2e
+
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline_bundles_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/tektoncd/resolution/test/helpers"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	knativetest "knative.dev/pkg/test"
+)
+
+// testNamespace is the namespace to construct and run this e2e test in.
+const testNamespace = "tekton-resolution-pipeline-bundles-test"
+
+// waitInterval is the duration between repeat attempts to check on the
+// status of the test's kubernetes resources.
+const waitInterval = time.Second
+
+// waitTimeout is the total maximum time the test may spend waiting for
+// successful creation or completion of resources deployed during this test.
+// The timeout is high because the CI/CD cluster can be slow.
+const waitTimeout = 2 * time.Minute
+
+// TestPipelineBundle executes a PipelineRun that relies on a Pipeline
+// from a Bundle stored in a registry.
+func TestPipelineBundle(t *testing.T) {
+	ctx := context.Background()
+	configPath := knativetest.Flags.Kubeconfig
+	clusterName := knativetest.Flags.Cluster
+
+	cfg, err := knativetest.BuildClientConfig(configPath, clusterName)
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create kubeclient from config file at %s: %s", configPath, err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("failed to create dynamic client from config file at %s: %s", configPath, err)
+	}
+
+	tearDown := func() {
+		err := kubeClient.CoreV1().Namespaces().Delete(ctx, testNamespace, metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("error deleting test namespace %q: %v", testNamespace, err)
+		}
+	}
+
+	knativetest.CleanupOnInterrupt(tearDown, t.Logf)
+	defer tearDown()
+
+	_, err = kubeClient.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNamespace,
+			Labels: map[string]string{
+				"resolution.tekton.dev/test-e2e": "true",
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create namespace %s for tests: %s", testNamespace, err)
+	}
+
+	serviceIP, err := deployRegistry(ctx, kubeClient)
+	if err != nil {
+		t.Fatalf("error deploying registry: %v", err)
+	}
+
+	bundleRef := fmt.Sprintf("%s:5000/simple/pipeline:latest", serviceIP)
+
+	pipelineYAML, err := os.ReadFile("./pipeline.yaml")
+	if err != nil {
+		t.Fatalf("unable to read pipeline yaml fixture: %v", err)
+	}
+
+	err = publishTestBundle(ctx, kubeClient, string(pipelineYAML), bundleRef)
+	if err != nil {
+		t.Fatalf("error publishing bundle: %v", err)
+	}
+
+	pipelineRunYAML, err := os.ReadFile("./pipelinerun.yaml")
+	if err != nil {
+		t.Fatalf("error reading pipelinerun yaml fixture: %v", err)
+	}
+	pipelineRunYAML = bytes.Replace(pipelineRunYAML, []byte("{{bundleRef}}"), []byte(bundleRef), 1)
+
+	// Create PipelineRun using dynamic client to avoid importing
+	// pipelines as dependency.
+	pipelineRun := &unstructured.Unstructured{}
+	_, _, err = scheme.Codecs.UniversalDeserializer().Decode(pipelineRunYAML, nil, pipelineRun)
+	if err != nil {
+		t.Fatalf("error parsing into unstructured pipelinerun: %v", err)
+	}
+	pipelineRunGVR := schema.GroupVersionResource{
+		Group:    "tekton.dev",
+		Version:  "v1beta1",
+		Resource: "pipelineruns",
+	}
+	if _, err := dynamicClient.Resource(pipelineRunGVR).Namespace(testNamespace).Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("error creating pipelinerun object: %v", err)
+	}
+
+	pipelineRunName, has, err := unstructured.NestedString(pipelineRun.UnstructuredContent(), "metadata", "name")
+	if err != nil {
+		t.Fatalf("error reading pipelinerun name: %v", err)
+	} else if !has {
+		t.Fatalf("expected pipelinerun to have metadata.name but none was found")
+	}
+
+	err = wait.PollImmediate(waitInterval, waitTimeout, func() (bool, error) {
+		pr, err := dynamicClient.Resource(pipelineRunGVR).Namespace(testNamespace).Get(ctx, pipelineRunName, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("error getting pipelinerun: %v", err)
+		}
+		conditions, err := getPipelineRunConditions(pr)
+		if err != nil {
+			t.Fatalf("error reading pipelinerun conditions: %v", err)
+		}
+		for _, condition := range conditions {
+			if condition["type"] == "Succeeded" {
+				switch condition["status"] {
+				case "Unknown":
+					return false, nil
+				case "False":
+					return false, fmt.Errorf("pipelinerun failed with reason %q and message %q", condition["reason"], condition["message"])
+				case "True":
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("pipelinerun did not succeed: %v", err)
+	}
+}
+
+// getPipelineRunConditions returns the status.conditions from an
+// unstructured pipelinerun. If no conditions are found a nil map and
+// nil error are returned.
+func getPipelineRunConditions(pr *unstructured.Unstructured) ([]map[string]string, error) {
+	conditions, has, err := unstructured.NestedSlice(pr.UnstructuredContent(), "status", "conditions")
+	if !has {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("invalid conditions: %v", err)
+	}
+	ret := []map[string]string{}
+	for _, cond := range conditions {
+		condition, ok := cond.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("received condition with unexpected layout: %#v", cond)
+		}
+		conditionMap := map[string]string{}
+		for condKey, condVal := range condition {
+			stringVal, ok := condVal.(string)
+			if !ok {
+				return nil, fmt.Errorf("non-string value in condition %#v", cond)
+			}
+			conditionMap[condKey] = stringVal
+		}
+		ret = append(ret, conditionMap)
+	}
+	return ret, nil
+}
+
+// publishTestBundle uses a pod running tkn to push a YAML file as a
+// bundle to the registry identified by bundleRef.
+func publishTestBundle(ctx context.Context, kubeClient kubernetes.Interface, bundleContent, bundleRef string) error {
+	pod := &v1.Pod{}
+	if err := helpers.ReadFileToObject("./pod-tkn-bundle-push.yaml", pod); err != nil {
+		return fmt.Errorf("error reading pod to publish bundle: %w", err)
+	}
+	pod.ObjectMeta.Namespace = testNamespace
+	pod.ObjectMeta.Annotations["pipeline_yaml"] = bundleContent
+	pod.ObjectMeta.Annotations["bundle_ref"] = bundleRef
+	_, err := kubeClient.CoreV1().Pods(testNamespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("error creating pod to publish bundle: %w", err)
+	}
+	err = wait.PollImmediate(waitInterval, waitTimeout, func() (bool, error) {
+		p, err := kubeClient.CoreV1().Pods(testNamespace).Get(ctx, pod.ObjectMeta.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		switch p.Status.Phase {
+		case corev1.PodSucceeded:
+			return true, nil
+		case corev1.PodFailed:
+			return false, fmt.Errorf("error publishing bundle. pod status: %#v", p.Status)
+		default:
+			return false, nil
+		}
+	})
+	return err
+}
+
+// deployRegistry submits a registry deployment and service to
+// kubernetes and then waits for them to come up and be ready. The
+// clusterIP of the service is returned on success.
+func deployRegistry(ctx context.Context, kubeClient kubernetes.Interface) (string, error) {
+	deployment := &appsv1.Deployment{}
+	if err := helpers.ReadFileToObject("./registry-deployment.yaml", deployment); err != nil {
+		return "", fmt.Errorf("error reading registry deployment: %w", err)
+	}
+
+	service := &corev1.Service{}
+	if err := helpers.ReadFileToObject("./registry-service.yaml", service); err != nil {
+		return "", fmt.Errorf("error reading registry service: %w", err)
+	}
+
+	_, err := kubeClient.AppsV1().Deployments(testNamespace).Create(ctx, deployment, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error creating registry deployment: %w", err)
+	}
+
+	_, err = kubeClient.CoreV1().Services(testNamespace).Create(ctx, service, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error creating registry service: %w", err)
+	}
+
+	err = wait.PollImmediate(waitInterval, waitTimeout, func() (bool, error) {
+		d, err := kubeClient.AppsV1().Deployments(testNamespace).Get(ctx, deployment.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		s, err := kubeClient.CoreV1().Services(testNamespace).Get(ctx, service.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if d.Status.ReadyReplicas > 0 && s.Spec.ClusterIP != "" && s.Spec.ClusterIP != corev1.ClusterIPNone {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("error waiting for deployment and service: %w", err)
+	}
+
+	s, err := kubeClient.CoreV1().Services(testNamespace).Get(ctx, service.Name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("error getting service: %w", err)
+	}
+
+	return s.Spec.ClusterIP, nil
+}

--- a/test/pipeline_bundles_test/pipelinerun.yaml
+++ b/test/pipeline_bundles_test/pipelinerun.yaml
@@ -1,0 +1,32 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: run-hello-pipeline
+spec:
+  pipelineRef:
+    resolver: bundles
+    resource:
+    - name: bundle
+      # This field will be replaced by the test code
+      value: {{bundleRef}}
+    - name: name
+      value: hello-pipeline
+    - name: kind
+      value: pipeline
+  params:
+  - name: username
+    value: "tekton pipelines"

--- a/test/pipeline_bundles_test/pod-tkn-bundle-push.yaml
+++ b/test/pipeline_bundles_test/pod-tkn-bundle-push.yaml
@@ -1,0 +1,36 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Pod
+apiVersion: v1
+metadata:
+  name: tkn-bundle-push
+  annotations:
+    pipeline_yaml: "populated by test"
+    bundle_ref: "populated by test"
+spec:
+  restartPolicy: Never
+  containers:
+  - name: tkn-bundle-push
+    image: gcr.io/tekton-releases/dogfooding/tkn
+    env:
+    - name: PIPELINE_YAML
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.annotations['pipeline_yaml']
+    - name: BUNDLE_REF
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.annotations['bundle_ref']
+    command: ["sh", "-c", "echo \"${PIPELINE_YAML}\" | tkn bundle push -f - $(BUNDLE_REF)"]

--- a/test/pipeline_bundles_test/registry-deployment.yaml
+++ b/test/pipeline_bundles_test/registry-deployment.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+spec:
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+      - name: registry
+        image: registry # TODO: multiarch; see pipeline's test/multiarch_utils.go

--- a/test/pipeline_bundles_test/registry-service.yaml
+++ b/test/pipeline_bundles_test/registry-service.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+spec:
+  ports:
+  - port: 5000
+  selector:
+    app: registry


### PR DESCRIPTION
Prior to this commit the e2e tests in this repo only checked the
behaviour of ResolutionRequests. This meant that we werent testing
scenarios involving Tekton Pipelines, only the contract that Pipelines
adheres to.

This commit introduces a bundles E2E test that deploys a registry, publishes
a bundle to it, and executes a PipelineRun using the bundles resolver.
This test is a very close cousin to an equivalent test in Pipelines that
uses Pipeline's built-in bundle resolution logic:
https://github.com/tektoncd/pipeline/blob/main/test/tektonbundles_test.go