### PR TITLE
Add hub resolver link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ $ ko apply -f ./config
 
 Resolvers do the heavy lifting fetching tekton resources from remote places (like repos, registries, etc...). These are the resolvers that are currently implemented. Once a Resolver is installed in your Tekton cluster all users in that cluster can start making use of it.
 
-| Name                                                        | Description                                                                     | Status    |
-|-------------------------------------------------------------|---------------------------------------------------------------------------------|-----------|
-| [`Bundle`](./bundleresolver)                                | Returns entries from oci bundles                                                | Alpha |
-| [`Git`](./gitresolver)                                      | Returns files from git repos                                                    | Alpha |
+| Name                                                        | Description                                                                      | Status    |
+|-------------------------------------------------------------|----------------------------------------------------------------------------------|-----------|
+| [`Bundle`](./bundleresolver)                                | Returns entries from oci bundles                                                 | Alpha |
+| [`Git`](./gitresolver)                                      | Returns files from git repos                                                     | Alpha |
+| [`Hub`](https://github.com/sbwsg/hubresolver)               | Uses the [Tekton Hub API](https://github.com/tektoncd/hub) to fetch tasks and pipelines | Alpha |
 | [`ClusterScoped`](https://github.com/sbwsg/clusterresolver) | Shares a single set of tasks and pipelines across all namespaces in your cluster | Alpha |
 
 Want to integrate with a remote location that isn't listed here? [Write a new resolver](./docs/how-to-write-a-resolver.md) or [post an issue requesting one](https://github.com/tektoncd/resolution/issues/new?assignees=&labels=kind%2Ffeature&template=feature-request.md).


### PR DESCRIPTION
This commit adds a link to a resolver that integrates pipelines with the tekton hub.