### PR TITLE
Add dependabot for gomod updates

### DIFF
--- a/.github/depandabot.yml
+++ b/.github/depandabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
Prior to this commit dependency updates were performed manually.

This commit adds configuration for github's dependabot so that it opens
pull requests weekly with any needed updates.