### PR TITLE
Rename "myresolver" to "demoresolver" in docs

### DIFF
--- a/docs/resolver-template/README.md
+++ b/docs/resolver-template/README.md
@@ -16,7 +16,7 @@ running with your own preferred storage backend.
 
 To reuse the template, simply copy this entire subdirectory to a new
 directory. The entire program is defined in
-[`./cmd/myresolver/main.go`](./cmd/myresolver/main.go) and provides stub
+[`./cmd/demoresolver/main.go`](./cmd/demoresolver/main.go) and provides stub
 implementations of all the methods defined by the [`framework.Resolver`
 interface](../../pkg/resolver/framework/interface.go).
 
@@ -25,7 +25,7 @@ of your project. We don't need this in `tektoncd/resolution` because this
 submodule relies on the `go.mod` and `go.sum` defined at the root of the repo.
 
 After your go module is initialized and dependencies tidied, update
-`config/myresolver-deployment.yaml`. The `image` field of the container
+`config/demo-resolver-deployment.yaml`. The `image` field of the container
 will need to point to your new go module's name, with a `ko://` prefix.
 
 ## Deploying the Resolver
@@ -42,15 +42,15 @@ will need to point to your new go module's name, with a `ko://` prefix.
 
 ### Install
 
-1. Install the `"myresolver"` Resolver:
+1. Install the `"demo"` Resolver:
 
 ```bash
-$ ko apply -f ./config/myresolver-deployment.yaml
+$ ko apply -f ./config/demo-resolver-deployment.yaml
 ```
 
 ### Testing it out
 
-Try creating a `ResolutionRequest` targeting `"myresolver"` with no parameters:
+Try creating a `ResolutionRequest` targeting `"demo"` with no parameters:
 
 ```bash
 $ cat <<EOF > rrtest.yaml
@@ -59,7 +59,7 @@ kind: ResolutionRequest
 metadata:
   name: test-resolver-template
   labels:
-    resolution.tekton.dev/type: myresolver
+    resolution.tekton.dev/type: demo
 EOF
 
 $ kubectl apply -f ./rrtest.yaml

--- a/docs/resolver-template/cmd/demoresolver/main.go
+++ b/docs/resolver-template/cmd/demoresolver/main.go
@@ -37,13 +37,13 @@ func (r *resolver) Initialize(context.Context) error {
 
 // GetName returns a string name to refer to this resolver by.
 func (r *resolver) GetName(context.Context) string {
-	return "myresolver"
+	return "Demo"
 }
 
 // GetSelector returns a map of labels to match requests to this resolver.
 func (r *resolver) GetSelector(context.Context) map[string]string {
 	return map[string]string{
-		common.LabelKeyResolverType: "myresolver",
+		common.LabelKeyResolverType: "demo",
 	}
 }
 

--- a/docs/resolver-template/config/demo-resolver-deployment.yaml
+++ b/docs/resolver-template/config/demo-resolver-deployment.yaml
@@ -14,17 +14,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: myresolver
+  name: demoresolver
   namespace: tekton-remote-resolution
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: myresolver
+      app: demoresolver
   template:
     metadata:
       labels:
-        app: myresolver
+        app: demoresolver
     spec:
       affinity:
         podAntiAffinity:
@@ -32,13 +32,13 @@ spec:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  app: myresolver
+                  app: demoresolver
               topologyKey: kubernetes.io/hostname
             weight: 100
       serviceAccountName: resolver
       containers:
       - name: controller
-        image: ko://github.com/tektoncd/resolution/docs/resolver-template/cmd/myresolver
+        image: ko://github.com/tektoncd/resolution/docs/resolver-template/cmd/demoresolver
         resources:
           requests:
             cpu: 100m

--- a/docs/resolver-template/test-resolver-template.yaml
+++ b/docs/resolver-template/test-resolver-template.yaml
@@ -16,4 +16,4 @@ apiVersion: resolution.tekton.dev/v1alpha1
 metadata:
   name: test-resolver-template
   labels:
-    resolution.tekton.dev/type: myresolver
+    resolution.tekton.dev/type: demo

--- a/test/smoke_test/resolution-request.yaml
+++ b/test/smoke_test/resolution-request.yaml
@@ -4,4 +4,4 @@ metadata:
   name: simple-resolution-request
   namespace: tekton-resolution-smoke-test
   labels:
-    resolution.tekton.dev/type: myresolver
+    resolution.tekton.dev/type: demo


### PR DESCRIPTION
Prior to this commit the docs provided a working resolver template for
developers that was named "myresolver".

This commit renames the default template from "myresolver" to
"demoresolver" and tweaks a bit of the template's code to make the
`GetName` and `GetSelector` methods a bit more idiomatic, dropping the
"resolver" portion of the name and they type.