### PR TITLE
Allow resolvers to watch configmaps and express custom request timeouts

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,11 +18,12 @@ package main
 
 import (
 	"github.com/tektoncd/resolution/pkg/reconciler/resolutionrequest"
+	"k8s.io/utils/clock"
 	"knative.dev/pkg/injection/sharedmain"
 )
 
 func main() {
 	sharedmain.Main("controller",
-		resolutionrequest.NewController,
+		resolutionrequest.NewController(clock.RealClock{}),
 	)
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,11 @@ For a developer getting started with writing a new Resolver, see
 [how-to-write-a-resolver.md](./how-to-write-a-resolver.md) and the
 accompanying [resolver-template](./resolver-template).
 
+## Resolver Reference: The interfaces and methods to implement
+
+For a table of the interfaces and methods a resolver must implement
+along with those that are optional, see [resolver-reference.md](./resolver-reference.md).
+
 ---
 
 Except as otherwise noted, the content of this page is licensed under the

--- a/docs/resolver-reference.md
+++ b/docs/resolver-reference.md
@@ -1,0 +1,50 @@
+# Resolver Reference
+
+Writing a resolver is made easier with the
+`github.com/tektoncd/resolution/pkg/resolver/framework` package.
+This package exposes a number of interfaces that let your code control
+what kind of behaviour it should have when running.
+
+To get started really quickly see the [resolver
+template](./resolver-template/), or for a howto guide see [how to write
+a resolver](./how-to-write-a-resolver.md).
+
+## The `Resolver` Interface
+
+Implementing this interface is required. It provides just enough
+configuration for the framework to get a resolver running.
+
+| Method  to Implement | Description |
+|----------------------|-------------|
+| Initialize | Use this method to perform any setup required before the resolver starts receiving requests. |
+| GetName | Use this method to return a name to refer to your Resolver by. e.g. `"Git"` |
+| GetSelector | Use this method to specify the labels that a resolution request must have to be routed to your resolver. |
+| ValidateParams | Use this method to validate the parameters given to your resolver. |
+| Resolve | Use this method to perform get the resource and return it, along with any metadata about it in annotations |
+
+## The `ConfigWatcher` Interface
+
+Implement this optional interface if your Resolver requires some amount
+of admin configuration. For example, if you want to allow admin users to
+configure things like timeouts, namespaces, lists of allowed registries,
+api endpoints or base urls, service account names to use, etc...
+
+| Method to Implement | Description |
+|---------------------|-------------|
+| GetConfigName       | Use this method to return the name of the configmap admins will use to configure this resolver. Once this interface is implemented your `ValidateParams` and `Resolve` methods will be able to access your latest resolver configuration by calling `framework.GetResolverConfigFromContext(ctx)`. Note that this configmap must exist when your resolver starts - put a default one in your resolver's `config/` directory. |
+
+## The `TimedResolution` Interface
+
+Implement this optional interface if your Resolver needs to custimze the
+timeout a resolution request can take. This may be based on knowledge of
+the underlying storage (e.g. some git repositories are slower to clone
+than others) or might be something an admin configures with a configmap.
+
+The default timeout of a request is 1 minute if this interface is not
+implemented. **Note**: There is currently a global maximum timeout of 1
+minute for _all_ resolution requests to prevent zombie requests
+remaining in an incomplete state forever.
+
+| Method to Implement | Description |
+|---------------------|-------------|
+| GetResolutionTimeout | Return a custom timeout duration from this method to control how long a resolution request to this resolver may take. |

--- a/gitresolver/README.md
+++ b/gitresolver/README.md
@@ -31,37 +31,21 @@ This Resolver responds to type `git`.
 $ ko apply -f ./gitresolver/config
 ```
 
-### Testing
+## Configuration
 
-Try creating a `ResolutionRequest` for a file in git:
+This resolver uses a `ConfigMap` for its settings. See
+[`./config/git-resolver-config.yaml`](./config/git-resolver-config.yaml)
+for the name, namespace and defaults that the resolver ships with.
 
-```bash
-$ cat <<EOF > rrtest.yaml
-apiVersion: resolution.tekton.dev/v1alpha1
-kind: ResolutionRequest
-metadata:
-  name: fetch-catalog-task
-  labels:
-    resolution.tekton.dev/type: git
-spec:
-  params:
-    url: https://github.com/tektoncd/catalog.git
-    path: /task/golang-build/0.3/golang-build.yaml
-EOF
+### Options
 
-$ kubectl apply -f ./rrtest.yaml
+| Option Name | Description | Example Values |
+|-------------|-------------|---------------|
+| `fetch-timeout` | The maximum time any single git resolution may take. **Note**: a global maximum timeout of 1 minute is currently enforced on _all_ resolution requests. | `1m`, `2s`, `700ms` |
 
-$ kubectl get resolutionrequest -w fetch-catalog-task
-```
+## Examples
 
-You should shortly see the `ResolutionRequest` succeed and the content of
-the `golang-build.yaml` file base64-encoded in the object's `status.data`
-field.
-
-### Example PipelineRun
-
-Here's an example PipelineRun that pulls in a simple pipeline from a fork
-of the Tekton Catalog:
+### `PipelineRun`
 
 ```yaml
 apiVersion: tekton.dev/v1beta1
@@ -83,13 +67,30 @@ spec:
     value: Ranni
 ```
 
+### `ResolutionRequest`
+
+```bash
+$ cat <<EOF > rrtest.yaml
+apiVersion: resolution.tekton.dev/v1alpha1
+kind: ResolutionRequest
+metadata:
+  name: fetch-catalog-task
+  labels:
+    resolution.tekton.dev/type: git
+spec:
+  params:
+    url: https://github.com/tektoncd/catalog.git
+    path: /task/golang-build/0.3/golang-build.yaml
+EOF
+
+$ kubectl apply -f ./rrtest.yaml
+
+$ kubectl get resolutionrequest -w fetch-catalog-task
+```
+
 ## What's Supported?
 
 - At the moment the git resolver can only access public repositories.
-- The git fetch must complete within 30 seconds. The `ResolutionRequest`
-  object will be automatically failed after 60 seconds. Both of these
-  timeouts need to be exposed for operator control via ConfigMap or
-  similar but at the moment are just hard-coded.
 
 ---
 

--- a/gitresolver/config/git-resolver-config.yaml
+++ b/gitresolver/config/git-resolver-config.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: git-resolver-config
+  namespace: tekton-remote-resolution
+data:
+  # The maximum amount of time a single git resolution may take.
+  fetch-timeout: "1m"

--- a/gitresolver/pkg/git/config.go
+++ b/gitresolver/pkg/git/config.go
@@ -1,0 +1,5 @@
+package git
+
+// ConfigFieldTimeout is the configuration field name for controlling
+// the maximum duration of a resolution request for a file from git.
+const ConfigFieldTimeout = "fetch-timeout"

--- a/gitresolver/pkg/git/resolver_test.go
+++ b/gitresolver/pkg/git/resolver_test.go
@@ -1,0 +1,103 @@
+package git
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	resolutioncommon "github.com/tektoncd/resolution/pkg/common"
+	"github.com/tektoncd/resolution/pkg/resolver/framework"
+)
+
+func TestGetSelector(t *testing.T) {
+	resolver := Resolver{}
+	sel := resolver.GetSelector(context.Background())
+	if typ, has := sel[resolutioncommon.LabelKeyResolverType]; !has {
+		t.Fatalf("unexpected selector: %v", sel)
+	} else if typ != LabelValueGitResolverType {
+		t.Fatalf("unexpected type: %q", typ)
+	}
+}
+
+func TestValidateParams(t *testing.T) {
+	resolver := Resolver{}
+
+	paramsWithCommit := map[string]string{
+		URLParam:    "foo",
+		PathParam:   "bar",
+		CommitParam: "baz",
+	}
+	if err := resolver.ValidateParams(context.Background(), paramsWithCommit); err != nil {
+		t.Fatalf("unexpected error validating params: %v", err)
+	}
+
+	paramsWithBranch := map[string]string{
+		URLParam:    "foo",
+		PathParam:   "bar",
+		BranchParam: "baz",
+	}
+	if err := resolver.ValidateParams(context.Background(), paramsWithBranch); err != nil {
+		t.Fatalf("unexpected error validating params: %v", err)
+	}
+}
+
+func TestValidateParamsMissing(t *testing.T) {
+	resolver := Resolver{}
+
+	var err error
+
+	paramsMissingURL := map[string]string{
+		PathParam:   "bar",
+		CommitParam: "baz",
+	}
+	err = resolver.ValidateParams(context.Background(), paramsMissingURL)
+	if err == nil {
+		t.Fatalf("expected missing url err")
+	}
+
+	paramsMissingPath := map[string]string{
+		URLParam:    "foo",
+		BranchParam: "baz",
+	}
+	err = resolver.ValidateParams(context.Background(), paramsMissingPath)
+	if err == nil {
+		t.Fatalf("expected missing path err")
+	}
+}
+
+func TestValidateParamsConflictingGitRef(t *testing.T) {
+	resolver := Resolver{}
+	params := map[string]string{
+		URLParam:    "foo",
+		PathParam:   "bar",
+		CommitParam: "baz",
+		BranchParam: "quux",
+	}
+	err := resolver.ValidateParams(context.Background(), params)
+	if err == nil {
+		t.Fatalf("expected err due to conflicting commit and branch params")
+	}
+}
+
+func TestGetResolutionTimeoutDefault(t *testing.T) {
+	resolver := Resolver{}
+	defaultTimeout := 30 * time.Minute
+	timeout := resolver.GetResolutionTimeout(context.Background(), defaultTimeout)
+	if timeout != defaultTimeout {
+		t.Fatalf("expected default timeout to be returned")
+	}
+}
+
+func TestGetResolutionTimeoutCustom(t *testing.T) {
+	resolver := Resolver{}
+	defaultTimeout := 30 * time.Minute
+	configTimeout := 5 * time.Second
+	config := map[string]string{
+		ConfigFieldTimeout: configTimeout.String(),
+	}
+	ctx := framework.InjectResolverConfigToContext(context.Background(), config)
+	timeout := resolver.GetResolutionTimeout(ctx, defaultTimeout)
+	if timeout != configTimeout {
+		t.Fatalf("expected timeout from config to be returned")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/client-go v0.23.5
 	k8s.io/code-generator v0.23.5
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	knative.dev/hack v0.0.0-20220328133751-f06773764ce3
 	knative.dev/pkg v0.0.0-20220329144915-0a1ec2e0d46c
 )
@@ -51,6 +52,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.15.0 // indirect
 	github.com/aws/smithy-go v1.11.0 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220228164355-396b2034c795 // indirect
+	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blendle/zapdriver v1.3.1 // indirect
@@ -138,7 +140,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.23.4 // indirect
 	k8s.io/gengo v0.0.0-20220307231824-4627b89bbf1b // indirect
 	k8s.io/klog/v2 v2.60.1-0.20220317184644-43cc75f9ae89 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/pkg/reconciler/resolutionrequest/resolutionrequest.go
+++ b/pkg/reconciler/resolutionrequest/resolutionrequest.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/resolution/pkg/apis/resolution/v1alpha1"
 	rrreconciler "github.com/tektoncd/resolution/pkg/client/injection/reconciler/resolution/v1alpha1/resolutionrequest"
 	resolutioncommon "github.com/tektoncd/resolution/pkg/common"
+	"k8s.io/utils/clock"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/reconciler"
@@ -31,11 +32,14 @@ import (
 
 // Reconciler is a knative reconciler for processing ResolutionRequest
 // objects
-type Reconciler struct{}
+type Reconciler struct {
+	clock clock.PassiveClock
+}
 
 var _ rrreconciler.Interface = (*Reconciler)(nil)
 
-// TODO(sbwsg): This should be exposed via ConfigMap.
+// TODO(sbwsg): This should be exposed via ConfigMap using a config
+// store similarly to Tekton Pipelines'.
 const defaultMaximumResolutionDuration = 1 * time.Minute
 
 // ReconcileKind processes updates to ResolutionRequests, sets status

--- a/pkg/resolver/framework/configstore.go
+++ b/pkg/resolver/framework/configstore.go
@@ -1,0 +1,70 @@
+package framework
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/configmap"
+)
+
+// resolverConfigKey is the contenxt key associated with configuration
+// for one specific resolver, and is only used if that resolver
+// implements the optional framework.ConfigWatcher interface.
+var resolverConfigKey = struct{}{}
+
+// DataFromConfigMap returns a copy of the contents of a configmap or an
+// empty map if the configmap doesn't have any data.
+func DataFromConfigMap(config *corev1.ConfigMap) (map[string]string, error) {
+	resolverConfig := map[string]string{}
+	if config == nil {
+		return resolverConfig, nil
+	}
+	for key, value := range config.Data {
+		resolverConfig[key] = value
+	}
+	return resolverConfig, nil
+}
+
+// ConfigStore wraps a knative untyped store and provides helper methods
+// for working with a resolver's configuration data.
+type ConfigStore struct {
+	resolverConfigName string
+	untyped            *configmap.UntypedStore
+}
+
+// GetResolverConfig returns a copy of the resolver's current
+// configuration or an empty map if the stored config is nil or invalid.
+func (store *ConfigStore) GetResolverConfig() map[string]string {
+	resolverConfig := map[string]string{}
+	untypedConf := store.untyped.UntypedLoad(store.resolverConfigName)
+	if conf, ok := untypedConf.(map[string]string); ok {
+		for key, val := range conf {
+			resolverConfig[key] = val
+		}
+	}
+	return resolverConfig
+}
+
+// ToContext returns a new context with the resolver's configuration
+// data stored in it.
+func (store *ConfigStore) ToContext(ctx context.Context) context.Context {
+	conf := store.GetResolverConfig()
+	return InjectResolverConfigToContext(ctx, conf)
+}
+
+// InjectResolverConfigToContext returns a new context with a
+// map stored in it for a resolvers config.
+func InjectResolverConfigToContext(ctx context.Context, conf map[string]string) context.Context {
+	return context.WithValue(ctx, resolverConfigKey, conf)
+}
+
+// GetResolverConfigFromContext returns any resolver-specific
+// configuration that has been stored or an empty map if none exists.
+func GetResolverConfigFromContext(ctx context.Context) map[string]string {
+	conf := map[string]string{}
+	storedConfig := ctx.Value(resolverConfigKey)
+	if resolverConfig, ok := storedConfig.(map[string]string); ok {
+		conf = resolverConfig
+	}
+	return conf
+}

--- a/pkg/resolver/framework/configstore_test.go
+++ b/pkg/resolver/framework/configstore_test.go
@@ -1,0 +1,76 @@
+package framework
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/configmap"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+// TestDataFromConfigMap checks that configmaps are correctly converted
+// into a map[string]string
+func TestDataFromConfigMap(t *testing.T) {
+	for _, tc := range []struct {
+		configMap *corev1.ConfigMap
+		expected  map[string]string
+	}{{
+		configMap: nil,
+		expected:  map[string]string{},
+	}, {
+		configMap: &corev1.ConfigMap{
+			Data: nil,
+		},
+		expected: map[string]string{},
+	}, {
+		configMap: &corev1.ConfigMap{
+			Data: map[string]string{},
+		},
+		expected: map[string]string{},
+	}, {
+		configMap: &corev1.ConfigMap{
+			Data: map[string]string{
+				"foo": "bar",
+			},
+		},
+		expected: map[string]string{
+			"foo": "bar",
+		},
+	}} {
+		out, err := DataFromConfigMap(tc.configMap)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !mapsAreEqual(tc.expected, out) {
+			t.Fatalf("expected %#v received %#v", tc.expected, out)
+		}
+	}
+}
+
+func TestGetResolverConfig(t *testing.T) {
+	_ = &ConfigStore{
+		resolverConfigName: "test",
+		untyped: configmap.NewUntypedStore(
+			"test-config",
+			logtesting.TestLogger(t),
+			configmap.Constructors{
+				"test": DataFromConfigMap,
+			},
+		),
+	}
+}
+
+func mapsAreEqual(m1, m2 map[string]string) bool {
+	if m1 == nil || m2 == nil {
+		return m1 == nil && m2 == nil
+	}
+	if len(m1) != len(m2) {
+		return false
+	}
+	for k, v := range m1 {
+		if m2[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/resolver/framework/interface.go
+++ b/pkg/resolver/framework/interface.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package framework
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Resolver is the interface to implement for type-specific resource
 // resolution. It fetches resources from a given type of remote location
@@ -45,6 +48,45 @@ type Resolver interface {
 	// is returned then its Reason and Message are used as part of the
 	// response to the request.
 	Resolve(context.Context, map[string]string) (ResolvedResource, error)
+}
+
+// ConfigWatcher is the interface to implement if your resolver accepts
+// additional configuration from an admin. Examples of how this
+// might be used:
+// - your resolver might require an allow-list of repositories or registries
+// - your resolver might allow request timeout settings to be configured
+// - your resolver might need an API endpoint or base url to be set
+//
+// When your resolver implements this interface it will be able to
+// access configuration from the context it receives in calls to
+// ValidateParams and Resolve.
+type ConfigWatcher interface {
+	// GetConfigName should return a string name for its
+	// configuration to be referenced by. This will map to the name
+	// of a ConfigMap in the same namespace as the resolver.
+	GetConfigName(context.Context) string
+}
+
+// TimedResolution is an optional interface that a resolver can
+// implement to override the default resolution request timeout.
+//
+// There are two timeouts that a resolution request adheres to: First
+// there is a global timeout that the core ResolutionRequest reconciler
+// enforces on _all_ requests. This prevents zombie requests (such as
+// those with a misconfigured `type`) sticking around in perpetuity.
+// Second there are resolver-specific timeouts that default to 1 minute.
+//
+// A resolver implemeting the TimedResolution interface sets the maximum
+// duration of any single request to this resolver.
+//
+// The core ResolutionRequest reconciler's global timeout overrides any
+// resolver-specific timeout.
+type TimedResolution interface {
+	// GetResolutionTimeout receives the current request's context
+	// object, which includes any request-scoped data like
+	// resolver config and the request's originating namespace,
+	// along with a default.
+	GetResolutionTimeout(context.Context, time.Duration) time.Duration
 }
 
 // ResolvedResource returns the data and annotations of a successful

--- a/vendor/github.com/benbjohnson/clock/LICENSE
+++ b/vendor/github.com/benbjohnson/clock/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Ben Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/benbjohnson/clock/README.md
+++ b/vendor/github.com/benbjohnson/clock/README.md
@@ -1,0 +1,104 @@
+clock
+=====
+
+Clock is a small library for mocking time in Go. It provides an interface
+around the standard library's [`time`][time] package so that the application
+can use the realtime clock while tests can use the mock clock.
+
+[time]: http://golang.org/pkg/time/
+
+
+## Usage
+
+### Realtime Clock
+
+Your application can maintain a `Clock` variable that will allow realtime and
+mock clocks to be interchangeable. For example, if you had an `Application` type:
+
+```go
+import "github.com/benbjohnson/clock"
+
+type Application struct {
+	Clock clock.Clock
+}
+```
+
+You could initialize it to use the realtime clock like this:
+
+```go
+var app Application
+app.Clock = clock.New()
+...
+```
+
+Then all timers and time-related functionality should be performed from the
+`Clock` variable.
+
+
+### Mocking time
+
+In your tests, you will want to use a `Mock` clock:
+
+```go
+import (
+	"testing"
+
+	"github.com/benbjohnson/clock"
+)
+
+func TestApplication_DoSomething(t *testing.T) {
+	mock := clock.NewMock()
+	app := Application{Clock: mock}
+	...
+}
+```
+
+Now that you've initialized your application to use the mock clock, you can
+adjust the time programmatically. The mock clock always starts from the Unix
+epoch (midnight UTC on Jan 1, 1970).
+
+
+### Controlling time
+
+The mock clock provides the same functions that the standard library's `time`
+package provides. For example, to find the current time, you use the `Now()`
+function:
+
+```go
+mock := clock.NewMock()
+
+// Find the current time.
+mock.Now().UTC() // 1970-01-01 00:00:00 +0000 UTC
+
+// Move the clock forward.
+mock.Add(2 * time.Hour)
+
+// Check the time again. It's 2 hours later!
+mock.Now().UTC() // 1970-01-01 02:00:00 +0000 UTC
+```
+
+Timers and Tickers are also controlled by this same mock clock. They will only
+execute when the clock is moved forward:
+
+```go
+mock := clock.NewMock()
+count := 0
+
+// Kick off a timer to increment every 1 mock second.
+go func() {
+    ticker := clock.Ticker(1 * time.Second)
+    for {
+        <-ticker.C
+        count++
+    }
+}()
+runtime.Gosched()
+
+// Move the clock forward 10 seconds.
+mock.Add(10 * time.Second)
+
+// This prints 10.
+fmt.Println(count)
+```
+
+

--- a/vendor/github.com/benbjohnson/clock/clock.go
+++ b/vendor/github.com/benbjohnson/clock/clock.go
@@ -1,0 +1,340 @@
+package clock
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// Clock represents an interface to the functions in the standard library time
+// package. Two implementations are available in the clock package. The first
+// is a real-time clock which simply wraps the time package's functions. The
+// second is a mock clock which will only change when
+// programmatically adjusted.
+type Clock interface {
+	After(d time.Duration) <-chan time.Time
+	AfterFunc(d time.Duration, f func()) *Timer
+	Now() time.Time
+	Since(t time.Time) time.Duration
+	Sleep(d time.Duration)
+	Tick(d time.Duration) <-chan time.Time
+	Ticker(d time.Duration) *Ticker
+	Timer(d time.Duration) *Timer
+}
+
+// New returns an instance of a real-time clock.
+func New() Clock {
+	return &clock{}
+}
+
+// clock implements a real-time clock by simply wrapping the time package functions.
+type clock struct{}
+
+func (c *clock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+func (c *clock) AfterFunc(d time.Duration, f func()) *Timer {
+	return &Timer{timer: time.AfterFunc(d, f)}
+}
+
+func (c *clock) Now() time.Time { return time.Now() }
+
+func (c *clock) Since(t time.Time) time.Duration { return time.Since(t) }
+
+func (c *clock) Sleep(d time.Duration) { time.Sleep(d) }
+
+func (c *clock) Tick(d time.Duration) <-chan time.Time { return time.Tick(d) }
+
+func (c *clock) Ticker(d time.Duration) *Ticker {
+	t := time.NewTicker(d)
+	return &Ticker{C: t.C, ticker: t}
+}
+
+func (c *clock) Timer(d time.Duration) *Timer {
+	t := time.NewTimer(d)
+	return &Timer{C: t.C, timer: t}
+}
+
+// Mock represents a mock clock that only moves forward programmatically.
+// It can be preferable to a real-time clock when testing time-based functionality.
+type Mock struct {
+	mu     sync.Mutex
+	now    time.Time   // current time
+	timers clockTimers // tickers & timers
+}
+
+// NewMock returns an instance of a mock clock.
+// The current time of the mock clock on initialization is the Unix epoch.
+func NewMock() *Mock {
+	return &Mock{now: time.Unix(0, 0)}
+}
+
+// Add moves the current time of the mock clock forward by the specified duration.
+// This should only be called from a single goroutine at a time.
+func (m *Mock) Add(d time.Duration) {
+	// Calculate the final current time.
+	t := m.now.Add(d)
+
+	// Continue to execute timers until there are no more before the new time.
+	for {
+		if !m.runNextTimer(t) {
+			break
+		}
+	}
+
+	// Ensure that we end with the new time.
+	m.mu.Lock()
+	m.now = t
+	m.mu.Unlock()
+
+	// Give a small buffer to make sure that other goroutines get handled.
+	gosched()
+}
+
+// Set sets the current time of the mock clock to a specific one.
+// This should only be called from a single goroutine at a time.
+func (m *Mock) Set(t time.Time) {
+	// Continue to execute timers until there are no more before the new time.
+	for {
+		if !m.runNextTimer(t) {
+			break
+		}
+	}
+
+	// Ensure that we end with the new time.
+	m.mu.Lock()
+	m.now = t
+	m.mu.Unlock()
+
+	// Give a small buffer to make sure that other goroutines get handled.
+	gosched()
+}
+
+// runNextTimer executes the next timer in chronological order and moves the
+// current time to the timer's next tick time. The next time is not executed if
+// its next time is after the max time. Returns true if a timer was executed.
+func (m *Mock) runNextTimer(max time.Time) bool {
+	m.mu.Lock()
+
+	// Sort timers by time.
+	sort.Sort(m.timers)
+
+	// If we have no more timers then exit.
+	if len(m.timers) == 0 {
+		m.mu.Unlock()
+		return false
+	}
+
+	// Retrieve next timer. Exit if next tick is after new time.
+	t := m.timers[0]
+	if t.Next().After(max) {
+		m.mu.Unlock()
+		return false
+	}
+
+	// Move "now" forward and unlock clock.
+	m.now = t.Next()
+	m.mu.Unlock()
+
+	// Execute timer.
+	t.Tick(m.now)
+	return true
+}
+
+// After waits for the duration to elapse and then sends the current time on the returned channel.
+func (m *Mock) After(d time.Duration) <-chan time.Time {
+	return m.Timer(d).C
+}
+
+// AfterFunc waits for the duration to elapse and then executes a function.
+// A Timer is returned that can be stopped.
+func (m *Mock) AfterFunc(d time.Duration, f func()) *Timer {
+	t := m.Timer(d)
+	t.C = nil
+	t.fn = f
+	return t
+}
+
+// Now returns the current wall time on the mock clock.
+func (m *Mock) Now() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.now
+}
+
+// Since returns time since the mock clock's wall time.
+func (m *Mock) Since(t time.Time) time.Duration {
+	return m.Now().Sub(t)
+}
+
+// Sleep pauses the goroutine for the given duration on the mock clock.
+// The clock must be moved forward in a separate goroutine.
+func (m *Mock) Sleep(d time.Duration) {
+	<-m.After(d)
+}
+
+// Tick is a convenience function for Ticker().
+// It will return a ticker channel that cannot be stopped.
+func (m *Mock) Tick(d time.Duration) <-chan time.Time {
+	return m.Ticker(d).C
+}
+
+// Ticker creates a new instance of Ticker.
+func (m *Mock) Ticker(d time.Duration) *Ticker {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ch := make(chan time.Time, 1)
+	t := &Ticker{
+		C:    ch,
+		c:    ch,
+		mock: m,
+		d:    d,
+		next: m.now.Add(d),
+	}
+	m.timers = append(m.timers, (*internalTicker)(t))
+	return t
+}
+
+// Timer creates a new instance of Timer.
+func (m *Mock) Timer(d time.Duration) *Timer {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ch := make(chan time.Time, 1)
+	t := &Timer{
+		C:       ch,
+		c:       ch,
+		mock:    m,
+		next:    m.now.Add(d),
+		stopped: false,
+	}
+	m.timers = append(m.timers, (*internalTimer)(t))
+	return t
+}
+
+func (m *Mock) removeClockTimer(t clockTimer) {
+	for i, timer := range m.timers {
+		if timer == t {
+			copy(m.timers[i:], m.timers[i+1:])
+			m.timers[len(m.timers)-1] = nil
+			m.timers = m.timers[:len(m.timers)-1]
+			break
+		}
+	}
+	sort.Sort(m.timers)
+}
+
+// clockTimer represents an object with an associated start time.
+type clockTimer interface {
+	Next() time.Time
+	Tick(time.Time)
+}
+
+// clockTimers represents a list of sortable timers.
+type clockTimers []clockTimer
+
+func (a clockTimers) Len() int           { return len(a) }
+func (a clockTimers) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a clockTimers) Less(i, j int) bool { return a[i].Next().Before(a[j].Next()) }
+
+// Timer represents a single event.
+// The current time will be sent on C, unless the timer was created by AfterFunc.
+type Timer struct {
+	C       <-chan time.Time
+	c       chan time.Time
+	timer   *time.Timer // realtime impl, if set
+	next    time.Time   // next tick time
+	mock    *Mock       // mock clock, if set
+	fn      func()      // AfterFunc function, if set
+	stopped bool        // True if stopped, false if running
+}
+
+// Stop turns off the ticker.
+func (t *Timer) Stop() bool {
+	if t.timer != nil {
+		return t.timer.Stop()
+	}
+
+	t.mock.mu.Lock()
+	registered := !t.stopped
+	t.mock.removeClockTimer((*internalTimer)(t))
+	t.stopped = true
+	t.mock.mu.Unlock()
+	return registered
+}
+
+// Reset changes the expiry time of the timer
+func (t *Timer) Reset(d time.Duration) bool {
+	if t.timer != nil {
+		return t.timer.Reset(d)
+	}
+
+	t.mock.mu.Lock()
+	t.next = t.mock.now.Add(d)
+	defer t.mock.mu.Unlock()
+
+	registered := !t.stopped
+	if t.stopped {
+		t.mock.timers = append(t.mock.timers, (*internalTimer)(t))
+	}
+
+	t.stopped = false
+	return registered
+}
+
+type internalTimer Timer
+
+func (t *internalTimer) Next() time.Time { return t.next }
+func (t *internalTimer) Tick(now time.Time) {
+	t.mock.mu.Lock()
+	if t.fn != nil {
+		t.fn()
+	} else {
+		t.c <- now
+	}
+	t.mock.removeClockTimer((*internalTimer)(t))
+	t.stopped = true
+	t.mock.mu.Unlock()
+	gosched()
+}
+
+// Ticker holds a channel that receives "ticks" at regular intervals.
+type Ticker struct {
+	C      <-chan time.Time
+	c      chan time.Time
+	ticker *time.Ticker  // realtime impl, if set
+	next   time.Time     // next tick time
+	mock   *Mock         // mock clock, if set
+	d      time.Duration // time between ticks
+}
+
+// Stop turns off the ticker.
+func (t *Ticker) Stop() {
+	if t.ticker != nil {
+		t.ticker.Stop()
+	} else {
+		t.mock.mu.Lock()
+		t.mock.removeClockTimer((*internalTicker)(t))
+		t.mock.mu.Unlock()
+	}
+}
+
+// Reset resets the ticker to a new duration.
+func (t *Ticker) Reset(dur time.Duration) {
+	if t.ticker != nil {
+		t.ticker.Reset(dur)
+	}
+}
+
+type internalTicker Ticker
+
+func (t *internalTicker) Next() time.Time { return t.next }
+func (t *internalTicker) Tick(now time.Time) {
+	select {
+	case t.c <- now:
+	default:
+	}
+	t.next = now.Add(t.d)
+	gosched()
+}
+
+// Sleep momentarily so that other goroutines can process.
+func gosched() { time.Sleep(1 * time.Millisecond) }

--- a/vendor/go.uber.org/zap/internal/ztest/clock.go
+++ b/vendor/go.uber.org/zap/internal/ztest/clock.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+// MockClock provides control over the time.
+type MockClock struct{ m *clock.Mock }
+
+// NewMockClock builds a new mock clock that provides control of time.
+func NewMockClock() *MockClock {
+	return &MockClock{clock.NewMock()}
+}
+
+// Now reports the current time.
+func (c *MockClock) Now() time.Time {
+	return c.m.Now()
+}
+
+// NewTicker returns a time.Ticker that ticks at the specified frequency.
+func (c *MockClock) NewTicker(d time.Duration) *time.Ticker {
+	return &time.Ticker{C: c.m.Ticker(d).C}
+}
+
+// Add progresses time by the given duration.
+func (c *MockClock) Add(d time.Duration) {
+	c.m.Add(d)
+}

--- a/vendor/go.uber.org/zap/internal/ztest/doc.go
+++ b/vendor/go.uber.org/zap/internal/ztest/doc.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package ztest provides low-level helpers for testing log output. These
+// utilities are helpful in zap's own unit tests, but any assertions using
+// them are strongly coupled to a single encoding.
+package ztest // import "go.uber.org/zap/internal/ztest"

--- a/vendor/go.uber.org/zap/internal/ztest/timeout.go
+++ b/vendor/go.uber.org/zap/internal/ztest/timeout.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+var _timeoutScale = 1.0
+
+// Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.
+func Timeout(base time.Duration) time.Duration {
+	return time.Duration(float64(base) * _timeoutScale)
+}
+
+// Sleep scales the sleep duration by $TEST_TIMEOUT_SCALE.
+func Sleep(base time.Duration) {
+	time.Sleep(Timeout(base))
+}
+
+// Initialize checks the environment and alters the timeout scale accordingly.
+// It returns a function to undo the scaling.
+func Initialize(factor string) func() {
+	original := _timeoutScale
+	fv, err := strconv.ParseFloat(factor, 64)
+	if err != nil {
+		panic(err)
+	}
+	_timeoutScale = fv
+	return func() { _timeoutScale = original }
+}
+
+func init() {
+	if v := os.Getenv("TEST_TIMEOUT_SCALE"); v != "" {
+		Initialize(v)
+		log.Printf("Scaling timeouts by %vx.\n", _timeoutScale)
+	}
+}

--- a/vendor/go.uber.org/zap/internal/ztest/writer.go
+++ b/vendor/go.uber.org/zap/internal/ztest/writer.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"strings"
+)
+
+// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
+type Syncer struct {
+	err    error
+	called bool
+}
+
+// SetError sets the error that the Sync method will return.
+func (s *Syncer) SetError(err error) {
+	s.err = err
+}
+
+// Sync records that it was called, then returns the user-supplied error (if
+// any).
+func (s *Syncer) Sync() error {
+	s.called = true
+	return s.err
+}
+
+// Called reports whether the Sync method was called.
+func (s *Syncer) Called() bool {
+	return s.called
+}
+
+// A Discarder sends all writes to ioutil.Discard.
+type Discarder struct{ Syncer }
+
+// Write implements io.Writer.
+func (d *Discarder) Write(b []byte) (int, error) {
+	return ioutil.Discard.Write(b)
+}
+
+// FailWriter is a WriteSyncer that always returns an error on writes.
+type FailWriter struct{ Syncer }
+
+// Write implements io.Writer.
+func (w FailWriter) Write(b []byte) (int, error) {
+	return len(b), errors.New("failed")
+}
+
+// ShortWriter is a WriteSyncer whose write method never fails, but
+// nevertheless fails to the last byte of the input.
+type ShortWriter struct{ Syncer }
+
+// Write implements io.Writer.
+func (w ShortWriter) Write(b []byte) (int, error) {
+	return len(b) - 1, nil
+}
+
+// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
+// a bytes.Buffer. It has convenience methods to split the accumulated buffer
+// on newlines.
+type Buffer struct {
+	bytes.Buffer
+	Syncer
+}
+
+// Lines returns the current buffer contents, split on newlines.
+func (b *Buffer) Lines() []string {
+	output := strings.Split(b.String(), "\n")
+	return output[:len(output)-1]
+}
+
+// Stripped returns the current buffer contents with the last trailing newline
+// stripped.
+func (b *Buffer) Stripped() string {
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/vendor/go.uber.org/zap/zaptest/doc.go
+++ b/vendor/go.uber.org/zap/zaptest/doc.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package zaptest provides a variety of helpers for testing log output.
+package zaptest // import "go.uber.org/zap/zaptest"

--- a/vendor/go.uber.org/zap/zaptest/logger.go
+++ b/vendor/go.uber.org/zap/zaptest/logger.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import (
+	"bytes"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// LoggerOption configures the test logger built by NewLogger.
+type LoggerOption interface {
+	applyLoggerOption(*loggerOptions)
+}
+
+type loggerOptions struct {
+	Level      zapcore.LevelEnabler
+	zapOptions []zap.Option
+}
+
+type loggerOptionFunc func(*loggerOptions)
+
+func (f loggerOptionFunc) applyLoggerOption(opts *loggerOptions) {
+	f(opts)
+}
+
+// Level controls which messages are logged by a test Logger built by
+// NewLogger.
+func Level(enab zapcore.LevelEnabler) LoggerOption {
+	return loggerOptionFunc(func(opts *loggerOptions) {
+		opts.Level = enab
+	})
+}
+
+// WrapOptions adds zap.Option's to a test Logger built by NewLogger.
+func WrapOptions(zapOpts ...zap.Option) LoggerOption {
+	return loggerOptionFunc(func(opts *loggerOptions) {
+		opts.zapOptions = zapOpts
+	})
+}
+
+// NewLogger builds a new Logger that logs all messages to the given
+// testing.TB.
+//
+//   logger := zaptest.NewLogger(t)
+//
+// Use this with a *testing.T or *testing.B to get logs which get printed only
+// if a test fails or if you ran go test -v.
+//
+// The returned logger defaults to logging debug level messages and above.
+// This may be changed by passing a zaptest.Level during construction.
+//
+//   logger := zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
+//
+// You may also pass zap.Option's to customize test logger.
+//
+//   logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+func NewLogger(t TestingT, opts ...LoggerOption) *zap.Logger {
+	cfg := loggerOptions{
+		Level: zapcore.DebugLevel,
+	}
+	for _, o := range opts {
+		o.applyLoggerOption(&cfg)
+	}
+
+	writer := newTestingWriter(t)
+	zapOptions := []zap.Option{
+		// Send zap errors to the same writer and mark the test as failed if
+		// that happens.
+		zap.ErrorOutput(writer.WithMarkFailed(true)),
+	}
+	zapOptions = append(zapOptions, cfg.zapOptions...)
+
+	return zap.New(
+		zapcore.NewCore(
+			zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+			writer,
+			cfg.Level,
+		),
+		zapOptions...,
+	)
+}
+
+// testingWriter is a WriteSyncer that writes to the given testing.TB.
+type testingWriter struct {
+	t TestingT
+
+	// If true, the test will be marked as failed if this testingWriter is
+	// ever used.
+	markFailed bool
+}
+
+func newTestingWriter(t TestingT) testingWriter {
+	return testingWriter{t: t}
+}
+
+// WithMarkFailed returns a copy of this testingWriter with markFailed set to
+// the provided value.
+func (w testingWriter) WithMarkFailed(v bool) testingWriter {
+	w.markFailed = v
+	return w
+}
+
+func (w testingWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+
+	// Strip trailing newline because t.Log always adds one.
+	p = bytes.TrimRight(p, "\n")
+
+	// Note: t.Log is safe for concurrent use.
+	w.t.Logf("%s", p)
+	if w.markFailed {
+		w.t.Fail()
+	}
+
+	return n, nil
+}
+
+func (w testingWriter) Sync() error {
+	return nil
+}

--- a/vendor/go.uber.org/zap/zaptest/testingt.go
+++ b/vendor/go.uber.org/zap/zaptest/testingt.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+// TestingT is a subset of the API provided by all *testing.T and *testing.B
+// objects.
+type TestingT interface {
+	// Logs the given message without failing the test.
+	Logf(string, ...interface{})
+
+	// Logs the given message and marks the test as failed.
+	Errorf(string, ...interface{})
+
+	// Marks the test as failed.
+	Fail()
+
+	// Returns true if the test has been marked as failed.
+	Failed() bool
+
+	// Returns the name of the test.
+	Name() string
+
+	// Marks the test as failed and stops execution of that test.
+	FailNow()
+}
+
+// Note: We currently only rely on Logf. We are including Errorf and FailNow
+// in the interface in anticipation of future need since we can't extend the
+// interface without a breaking change.

--- a/vendor/go.uber.org/zap/zaptest/timeout.go
+++ b/vendor/go.uber.org/zap/zaptest/timeout.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import (
+	"time"
+
+	"go.uber.org/zap/internal/ztest"
+)
+
+// Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.
+//
+// Deprecated: This function is intended for internal testing and shouldn't be
+// used outside zap itself. It was introduced before Go supported internal
+// packages.
+func Timeout(base time.Duration) time.Duration {
+	return ztest.Timeout(base)
+}
+
+// Sleep scales the sleep duration by $TEST_TIMEOUT_SCALE.
+//
+// Deprecated: This function is intended for internal testing and shouldn't be
+// used outside zap itself. It was introduced before Go supported internal
+// packages.
+func Sleep(base time.Duration) {
+	ztest.Sleep(base)
+}

--- a/vendor/go.uber.org/zap/zaptest/writer.go
+++ b/vendor/go.uber.org/zap/zaptest/writer.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import "go.uber.org/zap/internal/ztest"
+
+type (
+	// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
+	Syncer = ztest.Syncer
+
+	// A Discarder sends all writes to ioutil.Discard.
+	Discarder = ztest.Discarder
+
+	// FailWriter is a WriteSyncer that always returns an error on writes.
+	FailWriter = ztest.FailWriter
+
+	// ShortWriter is a WriteSyncer whose write method never returns an error,
+	// but always reports that it wrote one byte less than the input slice's
+	// length (thus, a "short write").
+	ShortWriter = ztest.ShortWriter
+
+	// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
+	// a bytes.Buffer. It has convenience methods to split the accumulated buffer
+	// on newlines.
+	Buffer = ztest.Buffer
+)

--- a/vendor/knative.dev/pkg/logging/testing/util.go
+++ b/vendor/knative.dev/pkg/logging/testing/util.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"knative.dev/pkg/logging"
+)
+
+// TestLogger gets a logger to use in unit and end to end tests
+func TestLogger(t zaptest.TestingT) *zap.SugaredLogger {
+	opts := zaptest.WrapOptions(
+		zap.AddCaller(),
+		zap.Development(),
+	)
+
+	return zaptest.NewLogger(t, opts).Sugar()
+}
+
+// TestContextWithLogger returns a context with a logger to be used in tests
+func TestContextWithLogger(t zaptest.TestingT) context.Context {
+	return logging.WithLogger(context.Background(), TestLogger(t))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,6 +159,9 @@ github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api
 github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cache
 github.com/awslabs/amazon-ecr-credential-helper/ecr-login/config
 github.com/awslabs/amazon-ecr-credential-helper/ecr-login/version
+# github.com/benbjohnson/clock v1.1.0
+## explicit; go 1.15
+github.com/benbjohnson/clock
 # github.com/beorn7/perks v1.0.1
 ## explicit; go 1.11
 github.com/beorn7/perks/quantile
@@ -507,7 +510,9 @@ go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
 go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
+go.uber.org/zap/internal/ztest
 go.uber.org/zap/zapcore
+go.uber.org/zap/zaptest
 # golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 ## explicit; go 1.17
 golang.org/x/crypto/blowfish
@@ -1157,6 +1162,7 @@ knative.dev/pkg/kmp
 knative.dev/pkg/leaderelection
 knative.dev/pkg/logging
 knative.dev/pkg/logging/logkey
+knative.dev/pkg/logging/testing
 knative.dev/pkg/metrics
 knative.dev/pkg/metrics/metricskey
 knative.dev/pkg/network


### PR DESCRIPTION
Prior to this commit all resolvers ran with a 30 second timeout for
resolution requests and didn't have a way to watch a configmap for
admin-level configuration.

This commit does several things:
1. Sets the default resolver timeout to 1 minute to match the global timeout
   enforced by the "core" ResolutionRequest reconciler.
2. Adds an optional interface for resolvers to implement that lets them
   set their own timeouts per-request.
3. To support configurable timeouts resolvers can now optionally name a
  a configmap to watch for admin settings. This is implemented as an
  optional interface that a resolver can implement.
4. The git resolver is updated to add support for a settings configmap
  that will eventually contain lots of interesting git-related settings but
  today is solely used to allow admins to set a custom timeout for git
  fetches.

Fixes https://github.com/tektoncd/resolution/issues/14

Still TODO:
- [x] Add tests for the gitresolver's timeout config
- [x] Add developer-facing docs for the new interfaces
- [x] Document the gitresolver's new timeout configuration