### PR TITLE
Migrate hubresolver

### DIFF
--- a/hubresolver/README.md
+++ b/hubresolver/README.md
@@ -1,0 +1,101 @@
+# Hub Resolver
+
+Use resolver type `hub`.
+
+## Parameters
+
+| Param Name       | Description                                                                   | Example Value                                              |
+|------------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
+| `catalog`        | The catalog from where to pull the resource (Optional)                        | Default:  `Tekton`                                         |
+| `kind`           | Either `task` or `pipeline`                                                   | `task`                                                     |
+| `name`           | The name of the task or pipeline to fetch from the hub                        | `golang-build`                                             |
+| `version`        | Version of task or pipeline to pull in from hub. Wrap the number in quotes!   | `"0.5"`                                                    |
+
+## Getting Started
+
+### Requirements
+
+See the [getting started
+instructions](https://github.com/tektoncd/resolution/tree/main/docs/getting-started.md)
+in the Tekton Resolution repo.
+
+### Install
+
+1. Install the Hub resolver:
+
+```bash
+$ ko apply -f ./config
+```
+
+### Configuring the Hub API endpoint
+
+By default this resolver will hit the public hub api at https://hub.tekton.dev/
+but you can configure your own (for example to use a private hub
+instance) by setting the `HUB_API` environment variable in
+`config/hubresolver-deployment.yaml`. Example:
+
+```yaml
+env
+- name: HUB_API
+  value: "https://api.hub.tekton.dev/"
+```
+
+### Testing it out
+
+Try creating a `ResolutionRequest` for a hub entry:
+
+```bash
+$ cat <<EOF > rrtest.yaml
+apiVersion: resolution.tekton.dev/v1alpha1
+kind: ResolutionRequest
+metadata:
+  name: fetch-hub-entry
+  labels:
+    resolution.tekton.dev/type: hub
+spec:
+  params:
+    kind: task
+    name: git-clone
+    version: "0.5"
+    kind: task
+EOF
+
+$ kubectl apply -f ./rrtest.yaml
+
+$ kubectl get resolutionrequest -w fetch-hub-entry
+```
+
+You should shortly see the `ResolutionRequest` succeed and the content of
+the `git-clone` yaml base64-encoded in the object's `status.data`
+field.
+
+### Example PipelineRun
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: hub-demo
+spec:
+  pipelineRef:
+    resolver: hub
+    resource:
+    - name: catalog # optional
+      value: Tekton 
+    - name: kind
+      value: pipeline
+    - name: name
+      value: buildpacks
+    - name: version
+      value: "0.1"
+  # Note: the buildpacks pipeline requires parameters.
+  # Resolution of the pipeline will succeed but the PipelineRun
+  # overall will not succeed without those parameters.
+```
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/hubresolver/cmd/hubresolver/main.go
+++ b/hubresolver/cmd/hubresolver/main.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/tektoncd/resolution/hubresolver/pkg/hub"
+	"github.com/tektoncd/resolution/pkg/resolver/framework"
+	"knative.dev/pkg/injection/sharedmain"
+)
+
+func main() {
+	apiURL := os.Getenv("HUB_API")
+	hubURL := hub.DefaultHubURL
+	if apiURL == "" {
+		hubURL = hub.DefaultHubURL
+	} else {
+		if !strings.HasSuffix(apiURL, "/") {
+			apiURL += "/"
+		}
+		hubURL = apiURL + hub.YamlEndpoint
+	}
+	fmt.Println("RUNNING WITH HUB URL PATTERN:", hubURL)
+	resolver := hub.Resolver{HubURL: hubURL}
+	sharedmain.Main("controller",
+		framework.NewController(context.Background(), &resolver),
+	)
+}

--- a/hubresolver/config/hubresolver-deployment.yaml
+++ b/hubresolver/config/hubresolver-deployment.yaml
@@ -1,0 +1,72 @@
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hubresolver
+  namespace: tekton-remote-resolution
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hubresolver
+  template:
+    metadata:
+      labels:
+        app: hubresolver
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: hubresolver
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: resolver
+      containers:
+      - name: controller
+        image: ko://github.com/tektoncd/resolution/hubresolver/cmd/hubresolver
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+        ports:
+        - name: metrics
+          containerPort: 9090
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: tekton.dev/resolution
+        # Override this env var to set a private hub api endpoint
+        - name: HUB_API
+          value: "https://api.hub.tekton.dev/"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - all

--- a/hubresolver/pkg/hub/params.go
+++ b/hubresolver/pkg/hub/params.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hub
+
+// DefaultHubURL is de default url for the Tekton hub api
+const DefaultHubURL = "https://api.hub.tekton.dev/v1/resource/%s/%s/%s/%s/yaml"
+
+// YamlEndpoint is the suffix for a private custom hub instance
+const YamlEndpoint = "v1/resource/%s/%s/%s/%s/yaml"
+
+// ParamName is the parameter defining what the layer name in the bundle
+// image is.
+const ParamName = "name"
+
+// ParamKind is the parameter defining what the layer kind in the bundle
+// image is.
+const ParamKind = "kind"
+
+// ParamVersion is the parameter defining what the layer version in the bundle
+// image is.
+const ParamVersion = "version"
+
+// ParamCatalog is the parameter defining what the catalog in the bundle
+// image is.
+const ParamCatalog = "catalog"

--- a/hubresolver/pkg/hub/resolver.go
+++ b/hubresolver/pkg/hub/resolver.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2022 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/tektoncd/resolution/pkg/common"
+	"github.com/tektoncd/resolution/pkg/resolver/framework"
+)
+
+// LabelValueHubResolverType is the value to use for the
+// resolution.tekton.dev/type label on resource requests
+const LabelValueHubResolverType string = "hub"
+
+const defaultCatalog string = "Tekton"
+
+// Resolver implements a framework.Resolver that can fetch files from OCI bundles.
+type Resolver struct {
+	// HubURL is the URL for hub resolver
+	HubURL string
+}
+
+// Initialize sets up any dependencies needed by the resolver. None atm.
+func (r *Resolver) Initialize(context.Context) error {
+	return nil
+}
+
+// GetName returns a string name to refer to this resolver by.
+func (r *Resolver) GetName(context.Context) string {
+	return "Hub"
+}
+
+// GetSelector returns a map of labels to match requests to this resolver.
+func (r *Resolver) GetSelector(context.Context) map[string]string {
+	return map[string]string{
+		common.LabelKeyResolverType: LabelValueHubResolverType,
+	}
+}
+
+// ValidateParams ensures parameters from a request are as expected.
+func (r *Resolver) ValidateParams(ctx context.Context, params map[string]string) error {
+	if kind, ok := params[ParamKind]; !ok {
+		return errors.New("must include kind param")
+	} else if kind != "task" && kind != "pipeline" {
+		return errors.New("kind param must be task or pipeline")
+	}
+	if _, ok := params[ParamName]; !ok {
+		return errors.New("must include name param")
+	}
+	if _, ok := params[ParamVersion]; !ok {
+		return errors.New("must include version param")
+	}
+
+	return nil
+}
+
+type dataResponse struct {
+	YAML string `json:"yaml"`
+}
+
+type hubResponse struct {
+	Data dataResponse `json:"data"`
+}
+
+// Resolve uses the given params to resolve the requested file or resource.
+func (r *Resolver) Resolve(ctx context.Context, params map[string]string) (framework.ResolvedResource, error) {
+	if _, ok := params[ParamCatalog]; !ok {
+		params[ParamCatalog] = defaultCatalog
+	}
+
+	url := fmt.Sprintf(r.HubURL, params[ParamCatalog], params[ParamKind], params[ParamName], params[ParamVersion])
+	// #nosec G107 -- URL cannot be constant in this case.
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("error requesting resource from hub: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+	hr := hubResponse{}
+	err = json.Unmarshal(body, &hr)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling json response: %w", err)
+	}
+	return &ResolvedHubResource{
+		Content: []byte(hr.Data.YAML),
+	}, nil
+}
+
+// ResolvedHubResource wraps the data we want to return to Pipelines
+type ResolvedHubResource struct {
+	Content []byte
+}
+
+var _ framework.ResolvedResource = &ResolvedHubResource{}
+
+// Data returns the bytes of our hard-coded Pipeline
+func (rr *ResolvedHubResource) Data() []byte {
+	return rr.Content
+}
+
+// Annotations returns any metadata needed alongside the data. None atm.
+func (*ResolvedHubResource) Annotations() map[string]string {
+	return nil
+}

--- a/hubresolver/pkg/hub/resolver_test.go
+++ b/hubresolver/pkg/hub/resolver_test.go
@@ -1,0 +1,173 @@
+package hub
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	resolutioncommon "github.com/tektoncd/resolution/pkg/common"
+	"github.com/tektoncd/resolution/test/diff"
+)
+
+func TestGetSelector(t *testing.T) {
+	resolver := Resolver{}
+	sel := resolver.GetSelector(context.Background())
+	if typ, has := sel[resolutioncommon.LabelKeyResolverType]; !has {
+		t.Fatalf("unexpected selector: %v", sel)
+	} else if typ != LabelValueHubResolverType {
+		t.Fatalf("unexpected type: %q", typ)
+	}
+}
+
+func TestValidateParams(t *testing.T) {
+	resolver := Resolver{}
+
+	paramsWithTask := map[string]string{
+		ParamKind:    "task",
+		ParamName:    "foo",
+		ParamVersion: "bar",
+	}
+	if err := resolver.ValidateParams(context.Background(), paramsWithTask); err != nil {
+		t.Fatalf("unexpected error validating params: %v", err)
+	}
+
+	paramsWithPipeline := map[string]string{
+		ParamKind:    "pipeline",
+		ParamName:    "foo",
+		ParamVersion: "bar",
+	}
+	if err := resolver.ValidateParams(context.Background(), paramsWithPipeline); err != nil {
+		t.Fatalf("unexpected error validating params: %v", err)
+	}
+}
+
+func TestValidateParamsMissing(t *testing.T) {
+	resolver := Resolver{}
+
+	var err error
+
+	paramsMissingKind := map[string]string{
+		ParamName:    "bar",
+		ParamVersion: "baz",
+	}
+	err = resolver.ValidateParams(context.Background(), paramsMissingKind)
+	if err == nil {
+		t.Fatalf("expected missing kind err")
+	}
+
+	paramsMissingName := map[string]string{
+		ParamKind:    "foo",
+		ParamVersion: "baz",
+	}
+	err = resolver.ValidateParams(context.Background(), paramsMissingName)
+	if err == nil {
+		t.Fatalf("expected missing name err")
+	}
+
+	paramsMissingVersion := map[string]string{
+		ParamKind:    "foo",
+		ParamVersion: "baz",
+	}
+	err = resolver.ValidateParams(context.Background(), paramsMissingVersion)
+	if err == nil {
+		t.Fatalf("expected missing version err")
+	}
+}
+
+func TestValidateParamsConflictingKindName(t *testing.T) {
+	resolver := Resolver{}
+	params := map[string]string{
+		ParamKind:    "not-task",
+		ParamName:    "foo",
+		ParamVersion: "bar",
+	}
+	err := resolver.ValidateParams(context.Background(), params)
+	if err == nil {
+		t.Fatalf("expected err due to conflicting kind param")
+	}
+}
+
+func TestResolve(t *testing.T) {
+	testCases := []struct {
+		name        string
+		kind        string
+		imageName   string
+		version     string
+		input       string
+		expectedRes []byte
+		expectedErr error
+	}{
+		{
+			name:        "valid response from hub",
+			kind:        "task",
+			imageName:   "foo",
+			version:     "baz",
+			input:       `{"data":{"yaml":"some content"}}`,
+			expectedRes: []byte("some content"),
+		},
+		{
+			name:        "not-found response from hub",
+			kind:        "task",
+			imageName:   "foo",
+			version:     "baz",
+			input:       `{"name":"not-found","id":"aaaaaaaa","message":"resource not found","temporary":false,"timeout":false,"fault":false}`,
+			expectedRes: []byte(""),
+		},
+		{
+			name:        "response with bad formatting error",
+			kind:        "task",
+			imageName:   "foo",
+			version:     "baz",
+			input:       `value`,
+			expectedErr: fmt.Errorf("error unmarshalling json response: invalid character 'v' looking for beginning of value"),
+		},
+		{
+			name:        "response with empty body error",
+			kind:        "task",
+			imageName:   "foo",
+			version:     "baz",
+			expectedErr: fmt.Errorf("error unmarshalling json response: unexpected end of JSON input"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, tc.input)
+			}))
+
+			resolver := &Resolver{HubURL: svr.URL + "/" + YamlEndpoint}
+
+			params := map[string]string{
+				ParamKind:    tc.kind,
+				ParamName:    tc.imageName,
+				ParamVersion: tc.version,
+			}
+
+			output, err := resolver.Resolve(context.Background(), params)
+			if tc.expectedErr != nil {
+				if err == nil {
+					t.Fatalf("expected err '%v' but didn't get one", tc.expectedErr)
+				}
+				if d := cmp.Diff(tc.expectedErr.Error(), err.Error()); d != "" {
+					t.Fatalf("expected err '%v' but got '%v'", tc.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error resolving: %v", err)
+				}
+
+				expectedResource := &ResolvedHubResource{
+					Content: tc.expectedRes,
+				}
+
+				if d := cmp.Diff(expectedResource, output); d != "" {
+					t.Errorf("unexpected resource from Resolve: %s", diff.PrintWantGot(d))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Migrate hubresolver from https://github.com/sbwsg/hubresolver to be
maintained by Tekton and would be used for remote resolution of
resources from the Tekton Hub.