### PR TITLE
Fix parameter typo in Git Resolver example

### DIFF
--- a/gitresolver/README.md
+++ b/gitresolver/README.md
@@ -60,7 +60,7 @@ spec:
       value: https://github.com/sbwsg/catalog.git
     - name: branch
       value: main
-    - name: path
+    - name: pathInRepo
       value: pipeline/simple/0.1/simple.yaml
   params:
   - name: name

--- a/gitresolver/examples/git_defaults.yaml
+++ b/gitresolver/examples/git_defaults.yaml
@@ -6,7 +6,7 @@ spec:
   pipelineRef:
     resolver: git
     resource:
-    - name: path
+    - name: pathInRepo
       value: pipeline/simple/0.1/simple.yaml
   params:
   - name: name


### PR DESCRIPTION
Prior to this change, "path" is used as the pipelineRef resolver resource parameter, this results in "missing pathInRepo" error when applying the examples. This commit fixes the issue by change "path" to "pathInRepo"