### PR TITLE
TEP-0115: Add git revision resolution suppot in Git Resolver

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -153,7 +153,7 @@ spec:
     resource:
     - name: url
       value: ${REPO_URL}
-    - name: branch
+    - name: revision
       value: add-a-simple-pipeline
     - name: path
       value: pipeline.yaml

--- a/gitresolver/README.md
+++ b/gitresolver/README.md
@@ -58,7 +58,7 @@ spec:
     resource:
     - name: url
       value: https://github.com/sbwsg/catalog.git
-    - name: branch
+    - name: revision
       value: main
     - name: pathInRepo
       value: pipeline/simple/0.1/simple.yaml

--- a/gitresolver/config/git-resolver-config.yaml
+++ b/gitresolver/config/git-resolver-config.yaml
@@ -22,5 +22,5 @@ data:
   fetch-timeout: "1m"
   # The git url to fetch the remote resource from.
   default-url: "https://github.com/tektoncd/catalog.git"
-  # The git branch to fetch the remote resource from.
-  default-branch: "main"
+  # The git revision to fetch the remote resource from.
+  default-revision: "main"

--- a/gitresolver/pkg/git/annotations.go
+++ b/gitresolver/pkg/git/annotations.go
@@ -17,7 +17,7 @@ limitations under the License.
 package git
 
 const (
-	// AnnotationKeyCommitHash is the commit hash that was fetched
+	// AnnotationKeyRevision is the revision that was fetched
 	// from git
-	AnnotationKeyCommitHash = "commit"
+	AnnotationKeyRevision = "revision"
 )

--- a/gitresolver/pkg/git/config.go
+++ b/gitresolver/pkg/git/config.go
@@ -8,6 +8,6 @@ const ConfigFieldTimeout = "fetch-timeout"
 // the git url to fetch the remote resource from.
 const ConfigURL = "default-url"
 
-// ConfigBranch is the configuration field name for controlling
-// the branch name to fetch the remote resource from.
-const ConfigBranch = "default-branch"
+// ConfigRevision is the configuration field name for controlling
+// the revision to fetch the remote resource from.
+const ConfigRevision = "default-revision"

--- a/gitresolver/pkg/git/params.go
+++ b/gitresolver/pkg/git/params.go
@@ -22,8 +22,5 @@ const URLParam string = "url"
 // PathParam is the pathInRepo into the git repo where a file is located
 const PathParam string = "pathInRepo"
 
-// CommitParam is the commit hash that a file should be fetched from
-const CommitParam string = "commit"
-
-// BranchParam is the git branch that a file should be fetched from
-const BranchParam string = "branch"
+// RevisionParam is the commit hash/branch/tag that a file should be fetched from
+const RevisionParam string = "revision"


### PR DESCRIPTION
Add git revision resolution support in Git Resolver

Prior to this change, users need to specify git commit or branch fields when using git resolver. This commits replaces the ```commit``` and ```branch``` with ```revision``` fields, which support git ```commit```, ```branch``` and ```tag```. This change extends the usability of git resolver and also provides a better user experience.