### PR TITLE
TEP-0115: Update git resolver doc to use "revision" and "pathInRepo" fields

### DIFF
--- a/gitresolver/README.md
+++ b/gitresolver/README.md
@@ -6,12 +6,11 @@ This Resolver responds to type `git`.
 
 ## Parameters
 
-| Param Name | Description                                                                  | Example Value                                |
-|------------|------------------------------------------------------------------------------|----------------------------------------------|
-| `url`      | URL of the repo to fetch.                                                    | `https://github.com/tektoncd/catalog.git`    |
-| `commit`   | git commit SHA to checkout a file from.                                      | `aeb957601cf41c012be462827053a21a420befca`   |
-| `branch`   | The branch name to checkout a file from. Either this or commit but not both. | `main`                                       |
-| `path`     | Where to find the file in the repo.                                          | `/task/golang-build/0.3/golang-build.yaml`   |
+| Param Name | Description                                                                  | Example Value                                               |
+|------------|------------------------------------------------------------------------------|-------------------------------------------------------------|
+| `url`      | URL of the repo to fetch.                                                    | `https://github.com/tektoncd/catalog.git`                   |
+| `revision` | Git revision to checkout a file from. This can be commit SHA, branch or tag. | `aeb957601cf41c012be462827053a21a420befca` `main` `v0.38.2` |
+| `pathInRepo` | Where to find the file in the repo.                                        | `/task/golang-build/0.3/golang-build.yaml`                  |
 
 ## Getting Started
 


### PR DESCRIPTION
Part of TEP-0115

Update Git Resolver documentation to use "revision" and "pathInRepo" fields to reflect the changes in [TEP-0115: Add git revision resolution support in Git Resolver](tektoncd/resolution#75) and [Add core Reconciler testing and fake resolver framework functions](tektoncd/resolution#51)